### PR TITLE
Add support for ipverse.net

### DIFF
--- a/nft-geo-filter
+++ b/nft-geo-filter
@@ -406,11 +406,11 @@ class GeoFilter:
         try:
             if self.provider == 'ipdeny.com':
                 if addr_family == 'ip':
-                    ipdeny_url = 'https://www.ipdeny.com/ipblocks/data/aggregated/{}-aggregated.zone'
+                    provider_url = 'https://www.ipdeny.com/ipblocks/data/aggregated/{}-aggregated.zone'
                 else:
-                    ipdeny_url = 'https://www.ipdeny.com/ipv6/ipaddresses/aggregated/{}-aggregated.zone'
+                    provider_url = 'https://www.ipdeny.com/ipv6/ipaddresses/aggregated/{}-aggregated.zone'
 
-                http_resp = urllib.request.urlopen(ipdeny_url.format(country_code))
+                http_resp = urllib.request.urlopen(provider_url.format(country_code))
                 data = http_resp.read().decode('utf-8')
 
                 self.logger.info('Building list of {} blocks for {}..'.format(log_addr_family, country_code))
@@ -420,11 +420,11 @@ class GeoFilter:
                 return ip_blocks
             elif self.provider == 'ipverse.net':
                 if addr_family == 'ip':
-                    ipdeny_url = 'http://ipverse.net/ipblocks/data/countries/{}.zone'
+                    provider_url = 'http://ipverse.net/ipblocks/data/countries/{}.zone'
                 else:
-                    ipdeny_url = 'http://ipverse.net/ipblocks/data/countries/{}-ipv6.zone'
+                    provider_url = 'http://ipverse.net/ipblocks/data/countries/{}-ipv6.zone'
 
-                http_resp = urllib.request.urlopen(ipdeny_url.format(country_code))
+                http_resp = urllib.request.urlopen(provider_url.format(country_code))
                 data = http_resp.read().decode('utf-8')
 
                 self.logger.info('Building list of {} blocks for {}..'.format(log_addr_family, country_code))
@@ -438,7 +438,7 @@ class GeoFilter:
 
                 return ip_blocks
         except urllib.error.HTTPError as err:
-            self.logger.error("Couldn't GET {}: {} {}".format(ipdeny_url.format(country_code), err.code, err.reason))
+            self.logger.error("Couldn't GET {}: {} {}".format(provider_url.format(country_code), err.code, err.reason))
             self.restore_old_sets()
             raise
         finally:

--- a/nft-geo-filter
+++ b/nft-geo-filter
@@ -394,10 +394,10 @@ class GeoFilter:
 
     def get_ip_blocks(self, country_code, addr_family):
         # We need to set the table as dormant before we try to download the IP blocks, because
-        # there is a possibility that ipdeny.com's IP address might be blocked by the filtering
-        # rule that was added when this script was previously executed. The dormant flag is
-        # removed as soon as the download is finished. By doing this, we are disabling the
-        # geo-filtering as little as possible.
+        # there is a possibility that the IP blocks provider's address might be blocked by the
+        # filtering rule that was added when this script was previously executed. The dormant
+        # flag is removed as soon as the download is finished. By doing this, we are disabling
+        # the geo-filtering as little as possible.
         self.set_table_as_dormant(True)
 
         log_addr_family = "IPv4" if addr_family == 'ip' else "IPv6"
@@ -566,8 +566,8 @@ if __name__ == '__main__':
 
     # Mandatory arguments
     parser.add_argument("country", nargs='+',
-        help=textwrap.dedent("""2 letter ISO-3166-1 alpha-2 country codes to block. Check
-            https://www.ipdeny.com/ipblocks/ to find the list of supported countries.""")
+        help=textwrap.dedent("""2 letter ISO-3166-1 alpha-2 country codes to allow/block. Check
+            your IP blocks provider to find the list of supported countries.""")
     )
 
     args = parser.parse_args()

--- a/nft-geo-filter
+++ b/nft-geo-filter
@@ -22,8 +22,7 @@ FILE_HEADER = ('table {} {} {{\n'
                'flags interval\n'
                'auto-merge\n')
 
-IPDENY_V4_URL= 'https://www.ipdeny.com/ipblocks/data/aggregated/{}-aggregated.zone'
-IPDENY_V6_URL= 'https://www.ipdeny.com/ipv6/ipaddresses/aggregated/{}-aggregated.zone'
+SUPPORTED_PROVIDERS = ('ipdeny.com', 'ipverse.net')
 
 class GeoFilter:
     def __init__(self, args):
@@ -43,6 +42,7 @@ class GeoFilter:
         self.log_drop_prefix = args.log_drop_prefix
         self.log_drop_level = args.log_drop_level
         self.verbosity = args.verbose
+        self.provider = args.provider
 
         self.working_dir = tempfile.mkdtemp()
         self.logger = self.configure_logging()
@@ -311,7 +311,7 @@ class GeoFilter:
                 raise
 
     def add_policy_logging_rule(self):
-        """Append a final rule with same action of the policy if 
+        """Append a final rule with same action of the policy if
         counter or logging with match to policy if required"""
         log_statement = self.create_log_statement(self.policy)
         if log_statement != "" or self.counter == "counter":
@@ -392,14 +392,64 @@ class GeoFilter:
             self.show_subprocess_run_error(err)
             raise
 
+    def get_ip_blocks(self, country_code, addr_family):
+        # We need to set the table as dormant before we try to download the IP blocks, because
+        # there is a possibility that ipdeny.com's IP address might be blocked by the filtering
+        # rule that was added when this script was previously executed. The dormant flag is
+        # removed as soon as the download is finished. By doing this, we are disabling the
+        # geo-filtering as little as possible.
+        self.set_table_as_dormant(True)
+
+        log_addr_family = "IPv4" if addr_family == 'ip' else "IPv6"
+        self.logger.info('Downloading "{}" {} blocks from {}'.format(country_code, log_addr_family, self.provider))
+
+        try:
+            if self.provider == 'ipdeny.com':
+                if addr_family == 'ip':
+                    ipdeny_url = 'https://www.ipdeny.com/ipblocks/data/aggregated/{}-aggregated.zone'
+                else:
+                    ipdeny_url = 'https://www.ipdeny.com/ipv6/ipaddresses/aggregated/{}-aggregated.zone'
+
+                http_resp = urllib.request.urlopen(ipdeny_url.format(country_code))
+                data = http_resp.read().decode('utf-8')
+
+                self.logger.info('Building list of {} blocks for {}..'.format(log_addr_family, country_code))
+                ip_blocks = ',\n'.join(data.splitlines())
+                self.logger.debug("IP block list for {}: {}".format(country_code, ip_blocks))
+
+                return ip_blocks
+            elif self.provider == 'ipverse.net':
+                if addr_family == 'ip':
+                    ipdeny_url = 'http://ipverse.net/ipblocks/data/countries/{}.zone'
+                else:
+                    ipdeny_url = 'http://ipverse.net/ipblocks/data/countries/{}-ipv6.zone'
+
+                http_resp = urllib.request.urlopen(ipdeny_url.format(country_code))
+                data = http_resp.read().decode('utf-8')
+
+                self.logger.info('Building list of {} blocks for {}..'.format(log_addr_family, country_code))
+
+                # Delete the comments on top of the IPverse IP blocks
+                data_list = data.splitlines()
+                data_without_comments = [d for d in data_list if d[0] != '#']
+
+                ip_blocks = ',\n'.join(data_without_comments)
+                self.logger.debug("IP block list for {}: {}".format(country_code, ip_blocks))
+
+                return ip_blocks
+        except urllib.error.HTTPError as err:
+            self.logger.error("Couldn't GET {}: {} {}".format(ipdeny_url.format(country_code), err.code, err.reason))
+            self.restore_old_sets()
+            raise
+        finally:
+            self.set_table_as_dormant(False)
+
     def update_filter_set(self, addr_family):
         if addr_family == 'ip':
-            ipdeny_url = IPDENY_V4_URL
             filter_set_type = "ipv4_addr"
             filter_set_name = "filter-v4"
             log_addr_family = "IPv4"
         elif addr_family == 'ip6':
-            ipdeny_url = IPDENY_V6_URL
             filter_set_type = "ipv6_addr"
             filter_set_name = "filter-v6"
             log_addr_family = "IPv6"
@@ -408,28 +458,8 @@ class GeoFilter:
         self.flush_filter_set(filter_set_name)
 
         for c in self.country_codes:
-            # We need to set the table as dormant before we try to download the IP blocks, because
-            # there is a possibility that ipdeny.com's IP address might be blocked by the filtering
-            # rule that was added when this script was previously executed. The dormant flag is
-            # removed as soon as the download is finished. By doing this, we are disabling the
-            # geo-filtering as little as possible.
-            self.set_table_as_dormant(True)
-
-            self.logger.info('Downloading "{}" {} blocks'.format(c, log_addr_family))
-            try:
-                ip_blocks = urllib.request.urlopen(ipdeny_url.format(c))
-                data = ip_blocks.read().decode('utf-8')
-            except urllib.error.HTTPError as err:
-                self.logger.error("Couldn't GET {}: {} {}".format(ipdeny_url.format(c), err.code, err.reason))
-                self.restore_old_sets()
-                raise
-            finally:
-                self.set_table_as_dormant(False)
-
-            self.logger.info('Building list of {} blocks..'.format(log_addr_family))
-            filter_set_ips = ',\n'.join(data.splitlines())
-            self.logger.debug("IP block list for {}: {}".format(c, filter_set_ips))
-            filter_set_ips = ''.join(('elements = {\n', filter_set_ips, '\n}\n}\n}'))
+            ip_blocks = self.get_ip_blocks(c, addr_family)
+            filter_set_ips = ''.join(('elements = {\n', ip_blocks, '\n}\n}\n}'))
 
             with tempfile.NamedTemporaryFile(mode='w', dir=self.working_dir, delete=False) as tmp:
                 tmp.write(FILE_HEADER.format(self.table_family, self.table_name, filter_set_name, filter_set_type))
@@ -473,6 +503,8 @@ if __name__ == '__main__':
     )
     nft_gfilter_group.add_argument("-c", "--counter", action="store_const", const="counter", default="",
         help="Add the counter statement to the filtering rules")
+    nft_gfilter_group.add_argument("--provider", action="store", default="ipdeny.com", choices=SUPPORTED_PROVIDERS,
+        help="Specify the country IP blocks provider. Default is ipdeny.com")
 
     # Table info
     table_group = parser.add_argument_group(


### PR DESCRIPTION
You can specify which country IP blocks provider you want to use by using the `--provider` flag. The default provider is set. to ipdeny.com.

```
  --provider {ipdeny.com,ipverse.net}
                        Specify the country IP blocks provider. Default is ipdeny.com
```

Fixes #12