### PR TITLE
Update IpVerse to ipverse-rir-ip

### DIFF
--- a/nft-geo-filter
+++ b/nft-geo-filter
@@ -425,9 +425,10 @@ class GeoFilter:
                 self.logger.debug("IP block list for {}: {}".format(country_code, ip_blocks))
             elif self.provider == 'ipverse.net':
                 if addr_family == 'ip':
-                    provider_url = 'http://ipverse.net/ipblocks/data/countries/{}.zone'
+                    provider_url = 'https://raw.githubusercontent.com/ipverse/rir-ip/master/country/{}/ipv4-aggregated.txt'
+
                 else:
-                    provider_url = 'http://ipverse.net/ipblocks/data/countries/{}-ipv6.zone'
+                    provider_url = 'https://raw.githubusercontent.com/ipverse/rir-ip/master/country/{}/ipv6-aggregated.txt'
 
                 http_resp = urllib.request.urlopen(provider_url.format(country_code))
                 data = http_resp.read().decode('utf-8')


### PR DESCRIPTION
The IpVerse domain is unavailable and is redirected to https://github.com/ipverse/rir-ip where new aggregate ip's are provided. This modification updates the referring url.